### PR TITLE
Fix: Archived issues are not resurrected into Needs Triage column

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -77,6 +77,13 @@
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
@@ -149,6 +156,13 @@
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {

--- a/README.md
+++ b/README.md
@@ -25,9 +25,14 @@ The generated files themselves have no impact on live FabricBot configuration. T
 
 *NodeJS is required.*
 
-* PowerShell: `./merge.ps1 generatedConfig repositoryConfig`
-    * Example: `./merge.ps1 .\generated\runtime.json D:\git\dotnet\runtime\.github\fabricbot.json`
-* Bash: `./merge.sh generatedConfig repositoryConfig`
-    * Example: `./merge.sh ./generated/runtime.json ~/git/dotnet/runtime/.github/fabricbot.json`
+```bash
+node ./src/merge.js generatedConfig repositoryConfig
+```
+
+*Example*
+
+```bash
+node ./src/merge.js ./generated/runtime.json ~/git/dotnet/runtime/.github/fabricbot.json
+```
 
 The merge script detects the Area Pod configuration tasks based on naming convention, and overwrites those tasks with the generated tasks; other tasks will remain unchanged.

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -301,6 +301,13 @@
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Adam / David - Issue Triage",
@@ -420,6 +427,13 @@
       ],
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -1108,6 +1122,13 @@
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
@@ -1251,6 +1272,13 @@
       ],
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -1938,6 +1966,13 @@
       "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
@@ -2063,6 +2098,13 @@
       ],
       "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -2630,6 +2672,13 @@
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
@@ -2737,6 +2786,13 @@
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -3230,6 +3286,13 @@
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
@@ -3331,6 +3394,13 @@
       ],
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -3738,6 +3808,13 @@
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
@@ -3821,6 +3898,13 @@
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -4453,6 +4537,13 @@
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
@@ -4608,6 +4699,13 @@
       ],
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -5260,6 +5358,13 @@
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
@@ -5367,6 +5472,13 @@
       ],
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -77,6 +77,13 @@
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
@@ -149,6 +156,13 @@
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -77,6 +77,13 @@
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
@@ -149,6 +156,13 @@
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -301,6 +301,13 @@
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Adam / David - Issue Triage",
@@ -420,6 +427,13 @@
       ],
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -1108,6 +1122,13 @@
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
@@ -1251,6 +1272,13 @@
       ],
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -1938,6 +1966,13 @@
       "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
@@ -2063,6 +2098,13 @@
       ],
       "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -2630,6 +2672,13 @@
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
@@ -2737,6 +2786,13 @@
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -3230,6 +3286,13 @@
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
@@ -3331,6 +3394,13 @@
       ],
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -3738,6 +3808,13 @@
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
@@ -3821,6 +3898,13 @@
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -4453,6 +4537,13 @@
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
@@ -4608,6 +4699,13 @@
       ],
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {
@@ -5260,6 +5358,13 @@
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Triage",
       "actions": [
         {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
+        {
           "name": "addToProject",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
@@ -5367,6 +5472,13 @@
       ],
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Further Triage",
       "actions": [
+        {
+          "name": "removeFromProject",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "isOrgProject": true
+          }
+        },
         {
           "name": "addToProject",
           "parameters": {

--- a/src/tasks/issueNeedsFurtherTriage.js
+++ b/src/tasks/issueNeedsFurtherTriage.js
@@ -78,6 +78,18 @@ module.exports = (pod, areas) => ({
     "taskName": `[Area Pod: ${pod} - Issue Triage] Needs Further Triage`,
     "actions":
     [
+      // Archived cards need to be removed/added instead of just added.
+      // There's no means for detecting/handling archive state, so this
+      // workaround is applied for all cards that need to be moved to
+      // the "Needs Triage" column.
+      {
+        "name": "removeFromProject",
+        "parameters":
+        {
+          "projectName": `Area Pod: ${pod} - Issue Triage`,
+          "isOrgProject": true
+        }
+      },
       {
         "name": "addToProject",
         "parameters":

--- a/src/tasks/issueNeedsTriage.js
+++ b/src/tasks/issueNeedsTriage.js
@@ -104,6 +104,18 @@ module.exports = (pod, areas) => ({
     "taskName": `[Area Pod: ${pod} - Issue Triage] Needs Triage`,
     "actions":
     [
+      // Archived cards need to be removed/added instead of just added.
+      // There's no means for detecting/handling archive state, so this
+      // workaround is applied for all cards that need to be moved to
+      // the "Needs Triage" column.
+      {
+        "name": "removeFromProject",
+        "parameters":
+        {
+          "projectName": `Area Pod: ${pod} - Issue Triage`,
+          "isOrgProject": true
+        }
+      },
       {
         "name": "addToProject",
         "parameters":


### PR DESCRIPTION
Fixes #4 by working around the limitations with archived cards. Instead of just adding the card into the _Needs Triage_ column, the card is removed from the project and then added to the project in that column. If the card had been archived in the _Triaged_ column, this has the net effect of adding it back to _Needs Triage_ and unarchiving it. If the card had not been archived, the net effect is the same of the card now being in the _Needs Triage_ column.