### PR TITLE
Automatically move into triager column when a pod member acts on an issue

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1878,16 +1878,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1929,16 +1956,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1575,6 +1575,94 @@
     "taskSource": "fabricbot-config",
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "ericstj"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: ericstj",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jeffhandley"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: jeffhandley",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
@@ -1815,7 +1903,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "ericstj",
+            "columnName": "Champion: ericstj",
             "isOrgProject": true
           }
         }
@@ -1866,7 +1954,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "jeffhandley",
+            "columnName": "Champion: jeffhandley",
             "isOrgProject": true
           }
         }

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -324,6 +324,94 @@
     "taskSource": "fabricbot-config",
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Adam / David - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "adamsitnik"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Adam / David - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "columnName": "Triage: adamsitnik",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Adam / David - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jozkee"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Adam / David - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "columnName": "Triage: jozkee",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
@@ -778,7 +866,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Adam / David - PRs",
-            "columnName": "adamsitnik",
+            "columnName": "Champion: adamsitnik",
             "isOrgProject": true
           }
         }
@@ -829,7 +917,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Adam / David - PRs",
-            "columnName": "jozkee",
+            "columnName": "Champion: jozkee",
             "isOrgProject": true
           }
         }
@@ -1243,6 +1331,138 @@
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "buyaa-n"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: buyaa-n",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "joperezr"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: joperezr",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "steveharter"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: steveharter",
             "isOrgProject": true
           }
         }
@@ -1799,7 +2019,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "buyaa-n",
+            "columnName": "Champion: buyaa-n",
             "isOrgProject": true
           }
         }
@@ -1850,7 +2070,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "joperezr",
+            "columnName": "Champion: joperezr",
             "isOrgProject": true
           }
         }
@@ -1901,7 +2121,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "steveharter",
+            "columnName": "Champion: steveharter",
             "isOrgProject": true
           }
         }
@@ -2246,6 +2466,94 @@
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "carlossanlop"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "columnName": "Triage: carlossanlop",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "bartonjs"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "columnName": "Triage: bartonjs",
             "isOrgProject": true
           }
         }
@@ -2733,7 +3041,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - PRs",
-            "columnName": "carlossanlop",
+            "columnName": "Champion: carlossanlop",
             "isOrgProject": true
           }
         }
@@ -2784,7 +3092,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - PRs",
-            "columnName": "bartonjs",
+            "columnName": "Champion: bartonjs",
             "isOrgProject": true
           }
         }
@@ -3060,6 +3368,138 @@
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: dakersnar",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: michaelgsharp",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: tannergooding",
             "isOrgProject": true
           }
         }
@@ -3478,7 +3918,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "dakersnar",
+            "columnName": "Champion: dakersnar",
             "isOrgProject": true
           }
         }
@@ -3529,7 +3969,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "michaelgsharp",
+            "columnName": "Champion: michaelgsharp",
             "isOrgProject": true
           }
         }
@@ -3580,7 +4020,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "tannergooding",
+            "columnName": "Champion: tannergooding",
             "isOrgProject": true
           }
         }
@@ -3833,6 +4273,138 @@
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "eiriktsarpalis"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: eiriktsarpalis",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "krwq"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: krwq",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "layomia"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: layomia",
             "isOrgProject": true
           }
         }
@@ -4228,7 +4800,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "eiriktsarpalis",
+            "columnName": "Champion: eiriktsarpalis",
             "isOrgProject": true
           }
         }
@@ -4279,7 +4851,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "krwq",
+            "columnName": "Champion: krwq",
             "isOrgProject": true
           }
         }
@@ -4330,7 +4902,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "layomia",
+            "columnName": "Champion: layomia",
             "isOrgProject": true
           }
         }
@@ -4514,6 +5086,94 @@
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "ericstj"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: ericstj",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jeffhandley"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: jeffhandley",
             "isOrgProject": true
           }
         }
@@ -4840,7 +5500,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "ericstj",
+            "columnName": "Champion: ericstj",
             "isOrgProject": true
           }
         }
@@ -4891,7 +5551,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "jeffhandley",
+            "columnName": "Champion: jeffhandley",
             "isOrgProject": true
           }
         }
@@ -5351,6 +6011,138 @@
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "eerhardt"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: eerhardt",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "maryamariyan"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: maryamariyan",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tarekgh"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: tarekgh",
             "isOrgProject": true
           }
         }
@@ -5953,7 +6745,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "eerhardt",
+            "columnName": "Champion: eerhardt",
             "isOrgProject": true
           }
         }
@@ -6004,7 +6796,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "maryamariyan",
+            "columnName": "Champion: maryamariyan",
             "isOrgProject": true
           }
         }
@@ -6055,7 +6847,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "tarekgh",
+            "columnName": "Champion: tarekgh",
             "isOrgProject": true
           }
         }
@@ -6331,6 +7123,94 @@
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "bartonjs"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "columnName": "Triage: bartonjs",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "GrabYourPitchForks"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "columnName": "Triage: GrabYourPitchForks",
             "isOrgProject": true
           }
         }
@@ -6749,7 +7629,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - PRs",
-            "columnName": "bartonjs",
+            "columnName": "Champion: bartonjs",
             "isOrgProject": true
           }
         }
@@ -6800,7 +7680,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - PRs",
-            "columnName": "GrabYourPitchForks",
+            "columnName": "Champion: GrabYourPitchForks",
             "isOrgProject": true
           }
         }

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -841,16 +841,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "adamsitnik"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -892,16 +919,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jozkee"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1994,16 +2048,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "buyaa-n"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -2045,16 +2126,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "joperezr"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -2096,16 +2204,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "steveharter"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3016,16 +3151,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "carlossanlop"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3067,16 +3229,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3893,16 +4082,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3944,16 +4160,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3995,16 +4238,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -4775,16 +5045,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eiriktsarpalis"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -4826,16 +5123,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "krwq"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -4877,16 +5201,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "layomia"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -5475,16 +5826,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -5526,16 +5904,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6720,16 +7125,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eerhardt"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6771,16 +7203,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "maryamariyan"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6822,16 +7281,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tarekgh"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -7604,16 +8090,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -7655,16 +8168,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "GrabYourPitchForks"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -1878,16 +1878,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1929,16 +1956,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -1575,6 +1575,94 @@
     "taskSource": "fabricbot-config",
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "ericstj"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: ericstj",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jeffhandley"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: jeffhandley",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
@@ -1815,7 +1903,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "ericstj",
+            "columnName": "Champion: ericstj",
             "isOrgProject": true
           }
         }
@@ -1866,7 +1954,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "jeffhandley",
+            "columnName": "Champion: jeffhandley",
             "isOrgProject": true
           }
         }

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -1553,6 +1553,138 @@
     "taskSource": "fabricbot-config",
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: dakersnar",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: michaelgsharp",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: tannergooding",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
@@ -1781,7 +1913,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "dakersnar",
+            "columnName": "Champion: dakersnar",
             "isOrgProject": true
           }
         }
@@ -1832,7 +1964,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "michaelgsharp",
+            "columnName": "Champion: michaelgsharp",
             "isOrgProject": true
           }
         }
@@ -1883,7 +2015,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "tannergooding",
+            "columnName": "Champion: tannergooding",
             "isOrgProject": true
           }
         }

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -1888,16 +1888,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1939,16 +1966,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -1990,16 +2044,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -2306,16 +2306,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "adamsitnik"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -2357,16 +2384,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jozkee"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3459,16 +3513,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "buyaa-n"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3510,16 +3591,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "joperezr"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -3561,16 +3669,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "steveharter"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -4481,16 +4616,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "carlossanlop"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -4532,16 +4694,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -5358,16 +5547,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -5409,16 +5625,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -5460,16 +5703,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6240,16 +6510,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eiriktsarpalis"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6291,16 +6588,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "krwq"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6342,16 +6666,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "layomia"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6940,16 +7291,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -6991,16 +7369,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -8185,16 +8590,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eerhardt"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -8236,16 +8668,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "maryamariyan"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -8287,16 +8746,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tarekgh"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -9069,16 +9555,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },
@@ -9120,16 +9633,43 @@
             }
           },
           {
-            "name": "isAction",
-            "parameters": {
-              "action": "assigned"
-            }
-          },
-          {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "GrabYourPitchForks"
-            }
+            "operator": "or",
+            "operands": [
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "and",
+                "operands": [
+                  {
+                    "name": "isAction",
+                    "parameters": {
+                      "action": "opened"
+                    }
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       },

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -1789,6 +1789,94 @@
     "taskSource": "fabricbot-config",
     "taskType": "trigger",
     "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Adam / David - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "adamsitnik"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Adam / David - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "columnName": "Triage: adamsitnik",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Adam / David - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jozkee"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Adam / David - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Adam / David - Issue Triage",
+            "columnName": "Triage: jozkee",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
     "subCapability": "IssueCommentResponder",
     "version": "1.0",
     "config": {
@@ -2243,7 +2331,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Adam / David - PRs",
-            "columnName": "adamsitnik",
+            "columnName": "Champion: adamsitnik",
             "isOrgProject": true
           }
         }
@@ -2294,7 +2382,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Adam / David - PRs",
-            "columnName": "jozkee",
+            "columnName": "Champion: jozkee",
             "isOrgProject": true
           }
         }
@@ -2708,6 +2796,138 @@
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "buyaa-n"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: buyaa-n",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "joperezr"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: joperezr",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "steveharter"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Buyaa / Jose / Steve - Issue Triage",
+            "columnName": "Triage: steveharter",
             "isOrgProject": true
           }
         }
@@ -3264,7 +3484,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "buyaa-n",
+            "columnName": "Champion: buyaa-n",
             "isOrgProject": true
           }
         }
@@ -3315,7 +3535,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "joperezr",
+            "columnName": "Champion: joperezr",
             "isOrgProject": true
           }
         }
@@ -3366,7 +3586,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
-            "columnName": "steveharter",
+            "columnName": "Champion: steveharter",
             "isOrgProject": true
           }
         }
@@ -3711,6 +3931,94 @@
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "carlossanlop"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "columnName": "Triage: carlossanlop",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "bartonjs"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Carlos / Jeremy - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Carlos / Jeremy - Issue Triage",
+            "columnName": "Triage: bartonjs",
             "isOrgProject": true
           }
         }
@@ -4198,7 +4506,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - PRs",
-            "columnName": "carlossanlop",
+            "columnName": "Champion: carlossanlop",
             "isOrgProject": true
           }
         }
@@ -4249,7 +4557,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Carlos / Jeremy - PRs",
-            "columnName": "bartonjs",
+            "columnName": "Champion: bartonjs",
             "isOrgProject": true
           }
         }
@@ -4525,6 +4833,138 @@
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "dakersnar"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: dakersnar",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "michaelgsharp"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: michaelgsharp",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tannergooding"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Drew / Michael / Tanner - Issue Triage",
+            "columnName": "Triage: tannergooding",
             "isOrgProject": true
           }
         }
@@ -4943,7 +5383,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "dakersnar",
+            "columnName": "Champion: dakersnar",
             "isOrgProject": true
           }
         }
@@ -4994,7 +5434,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "michaelgsharp",
+            "columnName": "Champion: michaelgsharp",
             "isOrgProject": true
           }
         }
@@ -5045,7 +5485,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
-            "columnName": "tannergooding",
+            "columnName": "Champion: tannergooding",
             "isOrgProject": true
           }
         }
@@ -5298,6 +5738,138 @@
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "eiriktsarpalis"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: eiriktsarpalis",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "krwq"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: krwq",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "layomia"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eirik / Krzysztof / Layomi - Issue Triage",
+            "columnName": "Triage: layomia",
             "isOrgProject": true
           }
         }
@@ -5693,7 +6265,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "eiriktsarpalis",
+            "columnName": "Champion: eiriktsarpalis",
             "isOrgProject": true
           }
         }
@@ -5744,7 +6316,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "krwq",
+            "columnName": "Champion: krwq",
             "isOrgProject": true
           }
         }
@@ -5795,7 +6367,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
-            "columnName": "layomia",
+            "columnName": "Champion: layomia",
             "isOrgProject": true
           }
         }
@@ -5979,6 +6551,94 @@
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "ericstj"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: ericstj",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "jeffhandley"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Jeff - Issue Triage",
+            "columnName": "Triage: jeffhandley",
             "isOrgProject": true
           }
         }
@@ -6305,7 +6965,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "ericstj",
+            "columnName": "Champion: ericstj",
             "isOrgProject": true
           }
         }
@@ -6356,7 +7016,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Jeff - PRs",
-            "columnName": "jeffhandley",
+            "columnName": "Champion: jeffhandley",
             "isOrgProject": true
           }
         }
@@ -6816,6 +7476,138 @@
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "eerhardt"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: eerhardt",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "maryamariyan"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: maryamariyan",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "tarekgh"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Eric / Maryam / Tarek - Issue Triage",
+            "columnName": "Triage: tarekgh",
             "isOrgProject": true
           }
         }
@@ -7418,7 +8210,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "eerhardt",
+            "columnName": "Champion: eerhardt",
             "isOrgProject": true
           }
         }
@@ -7469,7 +8261,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "maryamariyan",
+            "columnName": "Champion: maryamariyan",
             "isOrgProject": true
           }
         }
@@ -7520,7 +8312,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
-            "columnName": "tarekgh",
+            "columnName": "Champion: tarekgh",
             "isOrgProject": true
           }
         }
@@ -7796,6 +8588,94 @@
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
             "columnName": "Needs Triage",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "bartonjs"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "columnName": "Triage: bartonjs",
+            "isOrgProject": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "taskSource": "fabricbot-config",
+    "taskType": "trigger",
+    "capabilityId": "IssueResponder",
+    "subCapability": "IssuesOnlyResponder",
+    "version": "1.0",
+    "config": {
+      "conditions": {
+        "operator": "and",
+        "operands": [
+          {
+            "name": "isInProjectColumn",
+            "parameters": {
+              "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+              "isOrgProject": true,
+              "columnName": "Needs Triage"
+            }
+          },
+          {
+            "name": "isActivitySender",
+            "parameters": {
+              "user": "GrabYourPitchForks"
+            }
+          }
+        ]
+      },
+      "eventType": "issue",
+      "eventNames": [
+        "issues",
+        "project_card"
+      ],
+      "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Triage Started",
+      "actions": [
+        {
+          "name": "moveToProjectColumn",
+          "parameters": {
+            "projectName": "Area Pod: Jeremy / Levi - Issue Triage",
+            "columnName": "Triage: GrabYourPitchForks",
             "isOrgProject": true
           }
         }
@@ -8214,7 +9094,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - PRs",
-            "columnName": "bartonjs",
+            "columnName": "Champion: bartonjs",
             "isOrgProject": true
           }
         }
@@ -8265,7 +9145,7 @@
           "name": "moveToProjectColumn",
           "parameters": {
             "projectName": "Area Pod: Jeremy / Levi - PRs",
-            "columnName": "GrabYourPitchForks",
+            "columnName": "Champion: GrabYourPitchForks",
             "isOrgProject": true
           }
         }

--- a/src/areaPods.js
+++ b/src/areaPods.js
@@ -74,7 +74,7 @@ const podAreas = {
 module.exports = [
   {
     podName: "Adam / David",
-    champions: [ "adamsitnik", "jozkee" ],
+    users: [ "adamsitnik", "jozkee" ],
     repos: {
       "runtime": podAreas["adam-david"],
       "dotnet-api-docs": podAreas["adam-david"]
@@ -82,7 +82,7 @@ module.exports = [
   },
   {
     podName: "Buyaa / Jose / Steve",
-    champions: [ "buyaa-n", "joperezr", "steveharter" ],
+    users: [ "buyaa-n", "joperezr", "steveharter" ],
     repos: {
       "runtime": podAreas["buyaa-jose-steve"],
       "dotnet-api-docs": podAreas["buyaa-jose-steve"]
@@ -90,7 +90,7 @@ module.exports = [
   },
   {
     podName: "Carlos / Jeremy",
-    champions: [ "carlossanlop", "bartonjs" ],
+    users: [ "carlossanlop", "bartonjs" ],
     repos: {
       "runtime": podAreas["carlos-jeremy"],
       "dotnet-api-docs": podAreas["carlos-jeremy"]
@@ -98,7 +98,7 @@ module.exports = [
   },
   {
     podName: "Drew / Michael / Tanner",
-    champions: [ "dakersnar", "michaelgsharp", "tannergooding" ],
+    users: [ "dakersnar", "michaelgsharp", "tannergooding" ],
     repos: {
       "machinelearning": true,
       "runtime": podAreas["drew-michael-tanner"],
@@ -107,7 +107,7 @@ module.exports = [
   },
   {
     podName: "Eirik / Krzysztof / Layomi",
-    champions: [ "eiriktsarpalis", "krwq", "layomia" ],
+    users: [ "eiriktsarpalis", "krwq", "layomia" ],
     repos: {
       "runtime": podAreas["eirik-krzysztof-layomi"],
       "dotnet-api-docs": podAreas["eirik-krzysztof-layomi"]
@@ -115,7 +115,7 @@ module.exports = [
   },
   {
     podName: "Eric / Jeff",
-    champions: [ "ericstj", "jeffhandley" ],
+    users: [ "ericstj", "jeffhandley" ],
     repos: {
       "fabricbot-config": true,
       "runtime": podAreas["eric-jeff"],
@@ -124,7 +124,7 @@ module.exports = [
   },
   {
     podName: "Eric / Maryam / Tarek",
-    champions: [ "eerhardt", "maryamariyan", "tarekgh" ],
+    users: [ "eerhardt", "maryamariyan", "tarekgh" ],
     repos: {
       "runtime": podAreas["eric-maryam-tarek"],
       "dotnet-api-docs": podAreas["eric-maryam-tarek"]
@@ -132,7 +132,7 @@ module.exports = [
   },
   {
     podName: "Jeremy / Levi",
-    champions: [ "bartonjs", "GrabYourPitchForks" ],
+    users: [ "bartonjs", "GrabYourPitchForks" ],
     repos: {
       "runtime": podAreas["jeremy-levi"],
       "dotnet-api-docs": podAreas["jeremy-levi"]

--- a/src/generate.js
+++ b/src/generate.js
@@ -58,9 +58,9 @@ for (const repo of repos) {
       // Filter to the area pods that have areas in this repo
       .filter(areaPod => !!areaPod.repos[repo])
       // Get a flat array of project board tasks for this pod in this repo
-      .flatMap(({podName, champions, repos}) => projectBoardTasks({
+      .flatMap(({podName, users, repos}) => projectBoardTasks({
         podName,
-        champions,
+        users,
         podAreas: repos[repo],
         triagedLabels: triagedLabels[repo]
       }))

--- a/src/projectBoardTasks/index.js
+++ b/src/projectBoardTasks/index.js
@@ -1,5 +1,6 @@
 const issueMovedToAnotherArea = require("./issueMovedToAnotherArea");
 const issueNeedsTriage = require("./issueNeedsTriage");
+const issueTriageStarted = require("./issueTriageStarted");
 const issueNeedsFurtherTriage = require("./issueNeedsFurtherTriage");
 const issueTriaged = require("./issueTriaged");
 const pullRequestMovedToAnotherArea = require("./pullRequestMovedToAnotherArea");
@@ -9,6 +10,7 @@ const pullRequestChampionAssigned = require("./pullRequestChampionAssigned");
 module.exports = (options) => [
   ...issueMovedToAnotherArea(options),
   ...issueNeedsTriage(options),
+  ...issueTriageStarted(options),
   ...issueNeedsFurtherTriage(options),
   ...issueTriaged(options),
   ...pullRequestMovedToAnotherArea(options),

--- a/src/projectBoardTasks/issueTriageStarted.js
+++ b/src/projectBoardTasks/issueTriageStarted.js
@@ -1,7 +1,7 @@
 module.exports = ({podName, users}) => users.map((user) => ({
   "taskType": "trigger",
   "capabilityId": "IssueResponder",
-  "subCapability": "PullRequestResponder",
+  "subCapability": "IssuesOnlyResponder",
   "version": "1.0",
   "config": {
     "conditions": {
@@ -10,36 +10,29 @@ module.exports = ({podName, users}) => users.map((user) => ({
         {
           "name": "isInProjectColumn",
           "parameters": {
-            "projectName": `Area Pod: ${podName} - PRs`,
-            "columnName": "Needs Champion",
-            "isOrgProject": true
+            "projectName": `Area Pod: ${podName} - Issue Triage`,
+            "isOrgProject": true,
+            "columnName": "Needs Triage"
           }
         },
         {
-          "name": "isAction",
-          "parameters": {
-            "action": "assigned"
-          }
-        },
-        {
-          "name": "isAssignedToUser",
+          "name": "isActivitySender",
           "parameters": { user }
         }
       ]
     },
-    "eventType": "pull_request",
+    "eventType": "issue",
     "eventNames": [
-      "pull_request",
       "issues",
       "project_card"
     ],
-    "taskName": `[Area Pod: ${podName} - PRs] Champion Assigned`,
+    "taskName": `[Area Pod: ${podName} - Issue Triage] Triage Started`,
     "actions": [
       {
         "name": "moveToProjectColumn",
         "parameters": {
-          "projectName": `Area Pod: ${podName} - PRs`,
-          "columnName": `Champion: ${user}`,
+          "projectName": `Area Pod: ${podName} - Issue Triage`,
+          "columnName": `Triage: ${user}`,
           "isOrgProject": true
         }
       }

--- a/src/projectBoardTasks/pullRequestChampionAssigned.js
+++ b/src/projectBoardTasks/pullRequestChampionAssigned.js
@@ -16,14 +16,39 @@ module.exports = ({podName, users}) => users.map((user) => ({
           }
         },
         {
-          "name": "isAction",
-          "parameters": {
-            "action": "assigned"
-          }
-        },
-        {
-          "name": "isAssignedToUser",
-          "parameters": { user }
+          "operator": "or",
+          "operands": [
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "assigned"
+                  }
+                },
+                {
+                  "name": "isAssignedToUser",
+                  "parameters": { user }
+                }
+              ]
+            },
+            {
+              "operator": "and",
+              "operands": [
+                {
+                  "name": "isAction",
+                  "parameters": {
+                    "action": "opened"
+                  }
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": { user }
+                }
+              ]
+            }
+          ]
         }
       ]
     },


### PR DESCRIPTION
Fixes #7 

When a pod member engages on an issue and the issue is still in the _Needs Triage_ column on their board, automatically move the issue into their _Triage_ column (if their triage column uses their GitHub username). This PR also revises the PR Champion column convention applied in #14 to match on "Champion: ${user}" instead of just the username. (There's enough real estate on the columns to keep the "Champion:" prefix on the column name.