### PR TITLE
Only resurrect issue cards if the comment author has (at most) Read permission

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -1548,8 +1548,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
@@ -1591,12 +1590,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -304,8 +304,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Triage",
       "actions": [
@@ -394,12 +393,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -1145,8 +1143,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Triage",
       "actions": [
@@ -1259,12 +1256,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -2009,8 +2005,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Carlos / Viktor - Issue Triage] Needs Triage",
       "actions": [
@@ -2105,12 +2100,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -2735,8 +2729,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
@@ -2813,12 +2806,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -3369,8 +3361,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Triage",
       "actions": [
@@ -3441,12 +3432,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -3911,8 +3901,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
@@ -3965,12 +3954,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -4660,8 +4648,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Triage",
       "actions": [
@@ -4786,12 +4773,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -5501,8 +5487,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Triage",
       "actions": [
@@ -5579,12 +5564,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -1548,8 +1548,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
@@ -1591,12 +1590,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -1526,8 +1526,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
@@ -1569,12 +1568,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -1769,8 +1769,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Adam / David - Issue Triage] Needs Triage",
       "actions": [
@@ -1859,12 +1858,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -2610,8 +2608,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Buyaa / Jose / Steve - Issue Triage] Needs Triage",
       "actions": [
@@ -2724,12 +2721,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -3474,8 +3470,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Carlos / Viktor - Issue Triage] Needs Triage",
       "actions": [
@@ -3570,12 +3565,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -4200,8 +4194,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Drew / Michael / Tanner - Issue Triage] Needs Triage",
       "actions": [
@@ -4278,12 +4271,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -4834,8 +4826,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eirik / Krzysztof / Layomi - Issue Triage] Needs Triage",
       "actions": [
@@ -4906,12 +4897,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -5376,8 +5366,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Jeff - Issue Triage] Needs Triage",
       "actions": [
@@ -5430,12 +5419,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -6125,8 +6113,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Eric / Maryam / Tarek - Issue Triage] Needs Triage",
       "actions": [
@@ -6251,12 +6238,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]
@@ -6966,8 +6952,7 @@
       },
       "eventType": "issue",
       "eventNames": [
-        "issues",
-        "project_card"
+        "issues"
       ],
       "taskName": "[Area Pod: Jeremy / Levi - Issue Triage] Needs Triage",
       "actions": [
@@ -7044,12 +7029,11 @@
             ]
           },
           {
-            "operator": "not",
             "operands": [
               {
                 "name": "activitySenderHasPermissions",
                 "parameters": {
-                  "permissions": "write"
+                  "permissions": "read"
                 }
               }
             ]

--- a/src/projectBoardTasks/issueNeedsFurtherTriage.js
+++ b/src/projectBoardTasks/issueNeedsFurtherTriage.js
@@ -29,12 +29,11 @@ module.exports = ({podName, podAreas}) => [{
           ]
         },
         {
-          "operator": "not",
           "operands": [
             {
               "name": "activitySenderHasPermissions",
               "parameters": {
-                "permissions": "write"
+                "permissions": "read"
               }
             }
           ]

--- a/src/projectBoardTasks/issueNeedsTriage.js
+++ b/src/projectBoardTasks/issueNeedsTriage.js
@@ -98,8 +98,7 @@ module.exports = ({podName, podAreas}) => [{
     "eventType": "issue",
     "eventNames":
     [
-      "issues",
-      "project_card"
+      "issues"
     ],
     "taskName": `[Area Pod: ${podName} - Issue Triage] Needs Triage`,
     "actions":


### PR DESCRIPTION
Fixes #6 by inverting the permission logic. It turns out that the condition that checks the user's permission is an "at most" check instead of an "at least" check. Therefore, checking for "write" permission doesn't work if the user has admin or maintain permissions (or triage permissions).

With this change, we will only resurrect issue cards (for needing further triage) if the comment author has (at most) Read permission. This behavior was tested via #23.