### PR TITLE
Refactor PR champion assignment to address race condition

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -2150,12 +2150,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2178,6 +2172,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
                   }
                 ]
               },
@@ -2192,6 +2192,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2230,12 +2253,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2258,6 +2275,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
                   }
                 ]
               },
@@ -2272,6 +2295,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -1045,12 +1045,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "adamsitnik"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -1072,6 +1066,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "adamsitnik"
                     }
                   }
                 ]
@@ -1134,6 +1134,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Adam / David - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -1172,12 +1195,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jozkee"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -1199,6 +1216,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jozkee"
                     }
                   }
                 ]
@@ -1261,6 +1284,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Adam / David - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2798,12 +2844,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "buyaa-n"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2825,6 +2865,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "buyaa-n"
                     }
                   }
                 ]
@@ -2911,6 +2957,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2949,12 +3018,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "joperezr"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2976,6 +3039,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "joperezr"
                     }
                   }
                 ]
@@ -3062,6 +3131,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -3100,12 +3192,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "steveharter"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -3127,6 +3213,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "steveharter"
                     }
                   }
                 ]
@@ -3213,6 +3305,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -3251,12 +3366,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "stephentoub"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -3278,6 +3387,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "stephentoub"
                     }
                   }
                 ]
@@ -3364,6 +3479,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "stephentoub"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4483,12 +4621,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "carlossanlop"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4510,6 +4642,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "carlossanlop"
                     }
                   }
                 ]
@@ -4578,6 +4716,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Carlos / Viktor - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4616,12 +4777,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "viktorhofer"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4643,6 +4798,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "viktorhofer"
                     }
                   }
                 ]
@@ -4711,6 +4872,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Carlos / Viktor - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "viktorhofer"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -5832,12 +6016,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -5859,6 +6037,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
                     }
                   }
                 ]
@@ -5909,6 +6093,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -5947,12 +6154,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -5974,6 +6175,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
                     }
                   }
                 ]
@@ -6024,6 +6231,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -6062,12 +6292,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -6089,6 +6313,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
                     }
                   }
                 ]
@@ -6139,6 +6369,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7214,12 +7467,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eiriktsarpalis"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7241,6 +7488,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
                     }
                   }
                 ]
@@ -7285,6 +7538,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7323,12 +7599,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "krwq"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7350,6 +7620,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "krwq"
                     }
                   }
                 ]
@@ -7394,6 +7670,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7432,12 +7731,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "layomia"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7459,6 +7752,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "layomia"
                     }
                   }
                 ]
@@ -7503,6 +7802,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -8300,12 +8622,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -8327,6 +8643,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
                     }
                   }
                 ]
@@ -8353,6 +8675,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -8391,12 +8736,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -8418,6 +8757,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
                     }
                   }
                 ]
@@ -8444,6 +8789,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -9933,12 +10301,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eerhardt"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -9960,6 +10322,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eerhardt"
                     }
                   }
                 ]
@@ -10058,6 +10426,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -10096,12 +10487,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "maryamariyan"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -10123,6 +10508,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "maryamariyan"
                     }
                   }
                 ]
@@ -10221,6 +10612,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -10259,12 +10673,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tarekgh"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -10286,6 +10694,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tarekgh"
                     }
                   }
                 ]
@@ -10384,6 +10798,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -11365,12 +11802,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -11392,6 +11823,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
                     }
                   }
                 ]
@@ -11442,6 +11879,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Jeremy / Levi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -11480,12 +11940,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "GrabYourPitchForks"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -11507,6 +11961,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
                     }
                   }
                 ]
@@ -11557,6 +12017,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Jeremy / Levi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -2150,12 +2150,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2178,6 +2172,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
                   }
                 ]
               },
@@ -2192,6 +2192,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2230,12 +2253,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2258,6 +2275,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
                   }
                 ]
               },
@@ -2272,6 +2295,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -2290,12 +2290,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2318,6 +2312,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
                   }
                 ]
               },
@@ -2332,6 +2332,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2370,12 +2393,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2398,6 +2415,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
                   }
                 ]
               },
@@ -2412,6 +2435,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2450,12 +2496,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2478,6 +2518,12 @@
                     "parameters": {
                       "action": "assigned"
                     }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
                   }
                 ]
               },
@@ -2492,6 +2538,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -2608,12 +2608,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "adamsitnik"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2635,6 +2629,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "adamsitnik"
                     }
                   }
                 ]
@@ -2697,6 +2697,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Adam / David - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "adamsitnik"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -2735,12 +2758,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jozkee"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -2762,6 +2779,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jozkee"
                     }
                   }
                 ]
@@ -2824,6 +2847,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Adam / David - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jozkee"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4455,12 +4501,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "buyaa-n"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4482,6 +4522,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "buyaa-n"
                     }
                   }
                 ]
@@ -4568,6 +4614,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "buyaa-n"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4606,12 +4675,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "joperezr"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4633,6 +4696,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "joperezr"
                     }
                   }
                 ]
@@ -4719,6 +4788,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "joperezr"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4757,12 +4849,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "steveharter"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4784,6 +4870,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "steveharter"
                     }
                   }
                 ]
@@ -4870,6 +4962,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "steveharter"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -4908,12 +5023,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "stephentoub"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -4935,6 +5044,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "stephentoub"
                     }
                   }
                 ]
@@ -5021,6 +5136,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Buyaa / Jose / Steve - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "stephentoub"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -6190,12 +6328,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "carlossanlop"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -6217,6 +6349,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "carlossanlop"
                     }
                   }
                 ]
@@ -6285,6 +6423,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Carlos / Viktor - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "carlossanlop"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -6323,12 +6484,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "viktorhofer"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -6350,6 +6505,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "viktorhofer"
                     }
                   }
                 ]
@@ -6418,6 +6579,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Carlos / Viktor - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "viktorhofer"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7611,12 +7795,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "dakersnar"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7638,6 +7816,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "dakersnar"
                     }
                   }
                 ]
@@ -7688,6 +7872,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "dakersnar"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7726,12 +7933,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "michaelgsharp"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7753,6 +7954,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "michaelgsharp"
                     }
                   }
                 ]
@@ -7803,6 +8010,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "michaelgsharp"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -7841,12 +8071,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tannergooding"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -7868,6 +8092,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tannergooding"
                     }
                   }
                 ]
@@ -7918,6 +8148,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Drew / Michael / Tanner - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tannergooding"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -9065,12 +9318,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eiriktsarpalis"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -9092,6 +9339,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
                     }
                   }
                 ]
@@ -9136,6 +9389,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eiriktsarpalis"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -9174,12 +9450,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "krwq"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -9201,6 +9471,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "krwq"
                     }
                   }
                 ]
@@ -9245,6 +9521,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "krwq"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -9283,12 +9582,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "layomia"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -9310,6 +9603,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "layomia"
                     }
                   }
                 ]
@@ -9354,6 +9653,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eirik / Krzysztof / Layomi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "layomia"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -10201,12 +10523,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "ericstj"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -10228,6 +10544,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "ericstj"
                     }
                   }
                 ]
@@ -10254,6 +10576,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "ericstj"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -10292,12 +10637,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "jeffhandley"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -10319,6 +10658,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "jeffhandley"
                     }
                   }
                 ]
@@ -10345,6 +10690,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Jeff - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "jeffhandley"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -11906,12 +12274,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "eerhardt"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -11933,6 +12295,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "eerhardt"
                     }
                   }
                 ]
@@ -12031,6 +12399,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "eerhardt"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -12069,12 +12460,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "maryamariyan"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -12096,6 +12481,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "maryamariyan"
                     }
                   }
                 ]
@@ -12194,6 +12585,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "maryamariyan"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -12232,12 +12646,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "tarekgh"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -12259,6 +12667,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "tarekgh"
                     }
                   }
                 ]
@@ -12357,6 +12771,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Eric / Maryam / Tarek - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "tarekgh"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -13388,12 +13825,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "bartonjs"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -13415,6 +13846,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "bartonjs"
                     }
                   }
                 ]
@@ -13465,6 +13902,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Jeremy / Levi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "bartonjs"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]
@@ -13503,12 +13963,6 @@
         "operator": "and",
         "operands": [
           {
-            "name": "isAssignedToUser",
-            "parameters": {
-              "user": "GrabYourPitchForks"
-            }
-          },
-          {
             "name": "isOpen",
             "parameters": {}
           },
@@ -13530,6 +13984,12 @@
                     "name": "isAction",
                     "parameters": {
                       "action": "assigned"
+                    }
+                  },
+                  {
+                    "name": "isAssignedToUser",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
                     }
                   }
                 ]
@@ -13580,6 +14040,29 @@
                         "parameters": {
                           "projectName": "Area Pod: Jeremy / Levi - PRs",
                           "isOrgProject": true
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "name": "isActivitySender",
+                    "parameters": {
+                      "user": "GrabYourPitchForks"
+                    }
+                  },
+                  {
+                    "operator": "or",
+                    "operands": [
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "opened"
+                        }
+                      },
+                      {
+                        "name": "isAction",
+                        "parameters": {
+                          "action": "reopened"
                         }
                       }
                     ]

--- a/src/projectBoardTasks/pullRequestChampionAssigned.js
+++ b/src/projectBoardTasks/pullRequestChampionAssigned.js
@@ -8,10 +8,6 @@ module.exports = ({podName, podAreas, podMembers}) => podMembers.map(({name, use
       "operator": "and",
       "operands": [
         {
-          "name": "isAssignedToUser",
-          "parameters": { user }
-        },
-        {
           "name": "isOpen",
           "parameters": {}
         },
@@ -35,6 +31,10 @@ module.exports = ({podName, podAreas, podMembers}) => podMembers.map(({name, use
                     "action": "assigned"
                   }
                 },
+                {
+                  "name": "isAssignedToUser",
+                  "parameters": { user }
+                }
               ]
             },
             {
@@ -55,6 +55,27 @@ module.exports = ({podName, podAreas, podMembers}) => podMembers.map(({name, use
                       "parameters": {
                         "projectName": `Area Pod: ${podName} - PRs`,
                         "isOrgProject": true
+                      }
+                    }
+                  ]
+                },
+                {
+                  "name": "isActivitySender",
+                  "parameters": { user },
+                },
+                {
+                  "operator": "or",
+                  "operands": [
+                    {
+                      "name": "isAction",
+                      "parameters": {
+                        "action": "opened"
+                      }
+                    },
+                    {
+                      "name": "isAction",
+                      "parameters": {
+                        "action": "reopened"
                       }
                     }
                   ]


### PR DESCRIPTION
The PR champion assignment logic was relying on the user being assigned, but that happens via a fabricbot rule, and rules do not trigger rules. Instead, that logic needs to check to see if:

1. The PR was in "Needs Champion", and it became assigned to the pod member; or
2. The PR is not yet on the project board, it matches one of the pod's areas, and it was opened or reopened by the pod member