### PR TITLE
Introduce System.IO.Hashing and System.DateTime area labels

### DIFF
--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -694,6 +694,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.IO.Hashing"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq.Parallel"
                     }
                   }
@@ -815,6 +826,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Hashing"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq.Parallel"
                         }
                       },
@@ -891,6 +908,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.IO"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.IO.Hashing"
                     }
                   },
                   {
@@ -1017,6 +1040,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -1685,6 +1714,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Hashing"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq.Parallel"
                         }
                       }
@@ -1783,6 +1823,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -1997,6 +2043,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Hashing"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq.Parallel"
                 }
               },
@@ -2149,6 +2201,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -2314,6 +2372,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Hashing"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq.Parallel"
                 }
               },
@@ -2469,6 +2533,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -8636,6 +8706,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.DateTime"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq"
                     }
                   }
@@ -8796,6 +8877,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.DateTime"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       },
@@ -8896,6 +8983,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.ComponentModel.DataAnnotations"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.DateTime"
                     }
                   },
                   {
@@ -9046,6 +9139,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -9877,6 +9976,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.DateTime"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       }
@@ -10014,6 +10124,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -10276,6 +10392,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -10468,6 +10590,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -10647,6 +10775,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -10836,6 +10970,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -11015,6 +11155,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -1646,6 +1646,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.IO.Hashing"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq.Parallel"
                     }
                   }
@@ -1767,6 +1778,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Hashing"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq.Parallel"
                         }
                       },
@@ -1843,6 +1860,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.IO"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.IO.Hashing"
                     }
                   },
                   {
@@ -1969,6 +1992,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -2709,6 +2738,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Hashing"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq.Parallel"
                         }
                       }
@@ -2807,6 +2847,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -3021,6 +3067,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Hashing"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq.Parallel"
                 }
               },
@@ -3173,6 +3225,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -3338,6 +3396,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Hashing"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq.Parallel"
                 }
               },
@@ -3493,6 +3557,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.IO"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Hashing"
                 }
               },
               {
@@ -9854,6 +9924,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.DateTime"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq"
                     }
                   }
@@ -10014,6 +10095,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.DateTime"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       },
@@ -10114,6 +10201,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.ComponentModel.DataAnnotations"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.DateTime"
                     }
                   },
                   {
@@ -10264,6 +10357,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -11189,6 +11288,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.DateTime"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       }
@@ -11326,6 +11436,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -11588,6 +11704,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -11780,6 +11902,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -11959,6 +12087,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {
@@ -12148,6 +12282,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -12327,6 +12467,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.ComponentModel.DataAnnotations"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.DateTime"
                 }
               },
               {

--- a/src/areaPods.js
+++ b/src/areaPods.js
@@ -7,6 +7,7 @@ const podAreas = {
     "area-System.Formats.Asn1",
     "area-System.Formats.Cbor",
     "area-System.IO",
+    "area-System.IO.Hashing",
     "area-System.Linq.Parallel",
     "area-System.Security"
   ],
@@ -58,6 +59,7 @@ const podAreas = {
     "area-System.Globalization",
     "area-System.Collections",
     "area-System.ComponentModel.DataAnnotations",
+    "area-System.DateTime",
     "area-System.Linq",
     "area-System.Text.Encoding",
     "area-System.Text.Encodings.Web",


### PR DESCRIPTION
1. The System.IO.Hashing area is being carved out as it's not a child of System.IO and better aligns with the area owners involved in System.Security
2. System.DateTime will be used for collecting date/time related API issues and PRs; they've traditionally just been routed into System.Runtime but treated as special cases

/cc @tarekgh @bartonjs 