### PR TITLE
Introduce System.IO.Ports area

### DIFF
--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -8717,6 +8717,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.IO.Ports"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq"
                     }
                   }
@@ -8883,6 +8894,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Ports"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       },
@@ -8989,6 +9006,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.DateTime"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.IO.Ports"
                     }
                   },
                   {
@@ -9145,6 +9168,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -9987,6 +10016,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Ports"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       }
@@ -10130,6 +10170,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -10398,6 +10444,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -10596,6 +10648,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -10781,6 +10839,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -10976,6 +11040,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -11161,6 +11231,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -9935,6 +9935,17 @@
                   {
                     "name": "hasLabel",
                     "parameters": {
+                      "label": "area-System.IO.Ports"
+                    }
+                  }
+                ]
+              },
+              {
+                "operator": "not",
+                "operands": [
+                  {
+                    "name": "hasLabel",
+                    "parameters": {
                       "label": "area-System.Linq"
                     }
                   }
@@ -10101,6 +10112,12 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Ports"
+                        }
+                      },
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       },
@@ -10207,6 +10224,12 @@
                     "name": "labelAdded",
                     "parameters": {
                       "label": "area-System.DateTime"
+                    }
+                  },
+                  {
+                    "name": "labelAdded",
+                    "parameters": {
+                      "label": "area-System.IO.Ports"
                     }
                   },
                   {
@@ -10363,6 +10386,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -11299,6 +11328,17 @@
                       {
                         "name": "hasLabel",
                         "parameters": {
+                          "label": "area-System.IO.Ports"
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "operator": "not",
+                    "operands": [
+                      {
+                        "name": "hasLabel",
+                        "parameters": {
                           "label": "area-System.Linq"
                         }
                       }
@@ -11442,6 +11482,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -11710,6 +11756,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -11908,6 +11960,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -12093,6 +12151,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {
@@ -12288,6 +12352,12 @@
               {
                 "name": "hasLabel",
                 "parameters": {
+                  "label": "area-System.IO.Ports"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
                   "label": "area-System.Linq"
                 }
               },
@@ -12473,6 +12543,12 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "area-System.DateTime"
+                }
+              },
+              {
+                "name": "hasLabel",
+                "parameters": {
+                  "label": "area-System.IO.Ports"
                 }
               },
               {

--- a/src/areaPods.js
+++ b/src/areaPods.js
@@ -60,6 +60,7 @@ const podAreas = {
     "area-System.Collections",
     "area-System.ComponentModel.DataAnnotations",
     "area-System.DateTime",
+    "area-System.IO.Ports",
     "area-System.Linq",
     "area-System.Text.Encoding",
     "area-System.Text.Encodings.Web",


### PR DESCRIPTION
This introduces the System.IO.Ports area. Issues and PRs for that area are special-cased and not generally routed to the owners of System.IO. The new area is assigned to Eirik/Krzysztof/Layomi/Tarek (with @krwq as the primary domain expert).

This repo is used to script out the generation of fabricbot.json files for affected repos (dotnet/runtime and dotnet/dotnet-api-docs). There will be subsequent PRs into those repositories.