### PR TITLE
Revert "Do not add the needs-further-triage label if untriaged label exists (#74)

### DIFF
--- a/.github/fabricbot.json
+++ b/.github/fabricbot.json
@@ -451,17 +451,6 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }

--- a/generated/dotnet-api-docs.json
+++ b/generated/dotnet-api-docs.json
@@ -438,17 +438,6 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }

--- a/generated/fabricbot-config.json
+++ b/generated/fabricbot-config.json
@@ -451,17 +451,6 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }

--- a/generated/machinelearning.json
+++ b/generated/machinelearning.json
@@ -451,17 +451,6 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }

--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -451,17 +451,6 @@
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }

--- a/src/issueAndPullRequestTasks/trackNeedsAuthorAction.js
+++ b/src/issueAndPullRequestTasks/trackNeedsAuthorAction.js
@@ -126,17 +126,6 @@ module.exports = () => [
           {
             "name": "isOpen",
             "parameters": {}
-          },
-          {
-            "operator": "not",
-            "operands": [
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "untriaged"
-                }
-              }
-            ]
           }
         ]
       }


### PR DESCRIPTION
This reverts commit 64c042f3c696922b00e08d2113b71e31e241f91b.

After merging #74 and preparing the dotnet/runtime PR to apply this change there, it was realized that this change would have an unintended consequence: It would no longer remove the `needs-author-action` label in this event either.

I'm reverting that PR and will file a new issue to make sure we get the details right since this isn't as straightforward as first though.

/cc @ManickaP