### PR TITLE
Make arch/os excludes pod-specific. Do not exclude arch-wasm from michael/tanner pod

### DIFF
--- a/generated/runtime.json
+++ b/generated/runtime.json
@@ -9375,17 +9375,6 @@
                     }
                   }
                 ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "hasLabel",
-                    "parameters": {
-                      "label": "arch-wasm"
-                    }
-                  }
-                ]
               }
             ]
           }
@@ -9578,17 +9567,6 @@
                     "name": "hasLabel",
                     "parameters": {
                       "label": "os-tvos"
-                    }
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "hasLabel",
-                    "parameters": {
-                      "label": "arch-wasm"
                     }
                   }
                 ]
@@ -10062,12 +10040,6 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "os-tvos"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "arch-wasm"
                 }
               }
             ]
@@ -10610,17 +10582,6 @@
                     }
                   }
                 ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "hasLabel",
-                    "parameters": {
-                      "label": "arch-wasm"
-                    }
-                  }
-                ]
               }
             ]
           }
@@ -10835,17 +10796,6 @@
                     "name": "hasLabel",
                     "parameters": {
                       "label": "os-tvos"
-                    }
-                  }
-                ]
-              },
-              {
-                "operator": "not",
-                "operands": [
-                  {
-                    "name": "hasLabel",
-                    "parameters": {
-                      "label": "arch-wasm"
                     }
                   }
                 ]
@@ -11251,12 +11201,6 @@
                 "name": "hasLabel",
                 "parameters": {
                   "label": "os-tvos"
-                }
-              },
-              {
-                "name": "hasLabel",
-                "parameters": {
-                  "label": "arch-wasm"
                 }
               }
             ]

--- a/src/areaPods.js
+++ b/src/areaPods.js
@@ -1,3 +1,17 @@
+const areaPodExclusionLabels = {
+  "runtime": [
+    "os-android",     // @steveisok; @akoeplinger
+    "os-maccatalyst", // @steveisok
+    "os-ios",         // @steveisok; @vargaz
+    "os-tizen",       // @alpencolt; @gbalykov, @hjleee, @wscho77, @clamp03
+    "os-tvos",        // @steveisok; @vargaz
+    "arch-wasm",      // @lewing; @BrzVlad
+  ],
+  "fabricbot-config": [
+    "test-exclusion"  // Allows us to test the exclusion rules within the fabricbot-config repo
+  ]
+};
+
 const podAreas = {
   "adam-david": [
     "area-Extensions-Caching",
@@ -84,6 +98,7 @@ module.exports = [
       "runtime": podAreas["adam-david"],
       "dotnet-api-docs": podAreas["adam-david"]
     },
+    areaPodExclusionLabels
   },
   {
     podName: "Buyaa / Steve",
@@ -94,7 +109,8 @@ module.exports = [
     repos: {
       "runtime": podAreas["buyaa-steve"],
       "dotnet-api-docs": podAreas["buyaa-steve"]
-    }
+    },
+    areaPodExclusionLabels
   },
   {
     podName: "Carlos / Viktor",
@@ -105,7 +121,8 @@ module.exports = [
     repos: {
       "runtime": podAreas["carlos-viktor"],
       "dotnet-api-docs": podAreas["carlos-viktor"]
-    }
+    },
+    areaPodExclusionLabels
   },
   {
     podName: "Michael / Tanner",
@@ -117,6 +134,10 @@ module.exports = [
       "machinelearning": true,
       "runtime": podAreas["michael-tanner"],
       "dotnet-api-docs": podAreas["michael-tanner"]
+    },
+    areaPodExclusionLabels: {
+      ...areaPodExclusionLabels,
+      runtime: areaPodExclusionLabels["runtime"].filter(label => label != "arch-wasm") // Don't exclude arch-wasm from this pod
     }
   },
   {
@@ -130,7 +151,8 @@ module.exports = [
     repos: {
       "runtime": podAreas["eirik-krzysztof-layomi-tarek"],
       "dotnet-api-docs": podAreas["eirik-krzysztof-layomi-tarek"]
-    }
+    },
+    areaPodExclusionLabels
   },
   {
     podName: "Eric / Jeff",
@@ -142,7 +164,8 @@ module.exports = [
       "fabricbot-config": true,
       "runtime": podAreas["eric-jeff"],
       "dotnet-api-docs": podAreas["eric-jeff"]
-    }
+    },
+    areaPodExclusionLabels
   },
   {
     podName: "Libraries Analyzers",
@@ -152,6 +175,7 @@ module.exports = [
     ],
     repos: {
       "runtime": ["code-fixer", "code-analyzer"]
-    }
+    },
+    areaPodExclusionLabels
   }
 ];

--- a/src/generate.js
+++ b/src/generate.js
@@ -70,20 +70,6 @@ const areaPodTriagedLabels = {
   "dotnet-api-docs":  ["needs-author-action"]
 };
 
-const areaPodExclusionLabels = {
-  "runtime": [
-    "os-android",     // @steveisok; @akoeplinger
-    "os-maccatalyst", // @steveisok
-    "os-ios",         // @steveisok; @vargaz
-    "os-tizen",       // @alpencolt; @gbalykov, @hjleee, @wscho77, @clamp03
-    "os-tvos",        // @steveisok; @vargaz
-    "arch-wasm",      // @lewing; @BrzVlad
-  ],
-  "fabricbot-config": [
-    "test-exclusion"  // Allows us to test the exclusion rules within the fabricbot-config repo
-  ]
-};
-
 for (const repo of repos) {
   const generatedTasks = [
     ...(repoWideTasks[repo] || []),
@@ -93,7 +79,7 @@ for (const repo of repos) {
       // Filter to the area pods that have areas in this repo
       .filter(areaPod => !!areaPod.repos[repo])
       // Get a flat array of project board tasks for this pod in this repo
-      .flatMap(({podName, podMembers, repos}) => projectBoardTasks({
+      .flatMap(({podName, podMembers, repos, areaPodExclusionLabels}) => projectBoardTasks({
         podName,
         podMembers,
         podAreas: repos[repo],


### PR DESCRIPTION
Per https://github.com/dotnet/runtime/pull/87040#discussion_r1214663228, we don't want to exclude `arch-wasm` from @michaelgsharp and @tannergooding's area pod.

This makes the area pod exclusion labels area-pod-specific, and it removes the `arch-wasm` label from their pod's exclusion list for the runtime repo.